### PR TITLE
Improve notice settings, sanitization, and frontend behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# simple-notice
-Simple notice plugin is a useful WordPress plugin which allow you to show simple notice on your frontend which users can easily hide.
+# Simple Notice
+
+Simple Notice is a lightweight WordPress plugin that shows a configurable notice on the front end of your site. Visitors can dismiss it automatically or manually, and you can control where and how it appears.
+
+## Features
+
+- Enable/disable the notice globally.
+- Display on all pages or a specific page/post.
+- Auto-hide or click-to-hide behavior with configurable delay.
+- Multiple position and style options.
+- Cookie-based suppression (show again after a number of days).
+- Optional “hide on mobile” toggle.
+- Shortcode to trigger notices from buttons/links.
+
+## Usage
+
+1. Go to **Settings → Simple Notice**.
+2. Configure the notice text, display rules, and styling.
+3. Save your settings.
+
+### Shortcode
+
+Use the shortcode below to trigger a notice from a button:
+
+```
+[smn_notice_btn text="My button" hide="auto" position="top center" style="bootstrap"]
+```
+
+**Shortcode attributes**
+
+- `text`: Button label and notice text.
+- `url`: Button link URL (default: `#`).
+- `class`: Custom CSS class for the button.
+- `hide`: `auto` or `click`.
+- `position`: One of the positions from the settings page.
+- `style`: `bootstrap`, `happyblue`, or `blackBg`.

--- a/assets/frontend/notice.js
+++ b/assets/frontend/notice.js
@@ -1,75 +1,81 @@
 ;(function ($) {
     "use strict"; // use strict to start
-    
+
     $(document).ready(function () {
-        
+        if (typeof smn_notice === "undefined") {
+            return;
+        }
+
+        if (parseInt(smn_notice.smn_hide_mobile, 10) === 1 && window.innerWidth < 768) {
+            return;
+        }
+
         // Cookie setup
         var visited = $.cookie('visited');
-        if(visited == 'yes') {
-             // second page load, cookie active
-        }else {
-            
+        var noticeShown = false;
+
+        if (visited !== 'yes') {
             // Custom style happyblue
             $.notify.addStyle('happyblue', {
-              html: "<div>☺<span data-notify-text/>☺ &times;</div>",
-              classes: {
-                base: {
-                  "white-space": "nowrap",
-                  "background-color": "lightblue",
-                  "padding": "5px"
-                },
-                superblue: {
-                  "color": "white",
-                  "background-color": "blue"
+                html: "<div>☺<span data-notify-text/>☺ &times;</div>",
+                classes: {
+                    base: {
+                        "white-space": "nowrap",
+                        "background-color": "lightblue",
+                        "padding": "5px"
+                    },
+                    superblue: {
+                        "color": "white",
+                        "background-color": "blue"
+                    }
                 }
-              }
             });
-            
+
             // Custom style blackBg
             $.notify.addStyle('blackBg', {
-              html: "<div><span data-notify-text/> &times;</div>",
-              classes: {
-                base: {
-                  "white-space": "nowrap",
-                  "background-color": "#000",
-                  "padding": "5px 20px",
-                  "color": "white"
-                },
-                superblue: {
-                  "color": "white",
-                  "background-color": "#000"
+                html: "<div><span data-notify-text/> &times;</div>",
+                classes: {
+                    base: {
+                        "white-space": "nowrap",
+                        "background-color": "#000",
+                        "padding": "5px 20px",
+                        "color": "white"
+                    },
+                    superblue: {
+                        "color": "white",
+                        "background-color": "#000"
+                    }
                 }
-              }
             });
-            
+
             // Notice Settings
             var smn_text = smn_notice.smn_text;
-            var smn_hide = smn_notice.smn_hide;
-            var smn_hide_delay = smn_notice.smn_hide_delay;
-            
-            if(smn_text){
-               $.notify(smn_text, {
-                   position: smn_notice.smn_position == smn_notice.smn_position ? smn_notice.smn_position : 'bottom center',
-                   autoHide: smn_hide == 1 ? true : false,
-                   autoHideDelay: smn_hide_delay,
-                   clickToHide: smn_hide == 2 ? true : false,
-                   style: smn_notice.smn_style == smn_notice.smn_style ? smn_notice.smn_style : 'bootstrap',
-                   showAnimation: 'slideDown'
-               });
+            var smn_hide = parseInt(smn_notice.smn_hide, 10);
+            var smn_hide_delay = parseInt(smn_notice.smn_hide_delay, 10);
+
+            if (smn_text) {
+                $.notify(smn_text, {
+                    position: smn_notice.smn_position || 'bottom center',
+                    autoHide: smn_hide === 1,
+                    autoHideDelay: smn_hide_delay || 5000,
+                    clickToHide: smn_hide === 2,
+                    style: smn_notice.smn_style || 'bootstrap',
+                    showAnimation: 'slideDown'
+                });
+                noticeShown = true;
             }
-            
         }
-        
+
         // Cookie expires date
-        var smn_cookie_expire = smn_notice.smn_cookie_expire;
-        if(smn_cookie_expire <= 0){
-            $.removeCookie('visited');
+        if (noticeShown) {
+            var smn_cookie_expire = parseInt(smn_notice.smn_cookie_expire, 10);
+            if (smn_cookie_expire <= 0) {
+                $.removeCookie('visited');
+            }
+            $.cookie('visited', 'yes', {
+                expires: smn_cookie_expire ? smn_cookie_expire : 0 // the number of days cookie will be effective
+            });
         }
-        $.cookie('visited', 'yes', {
-            expires: smn_cookie_expire?parseInt(smn_cookie_expire):0 // the number of days cookie  will be effective
-        });
-        
-        
     });
-    
+
 })(jQuery);

--- a/inc/admin-options.php
+++ b/inc/admin-options.php
@@ -1,154 +1,261 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sanitize notice text.
+ *
+ * @param string $value Input value.
+ * @return string
+ */
+function smn_notice_sanitize_text( $value ) {
+	return sanitize_text_field( $value );
+}
+
+/**
+ * Sanitize enable/disable flags.
+ *
+ * @param mixed $value Input value.
+ * @return int
+ */
+function smn_notice_sanitize_toggle( $value ) {
+	return (int) (bool) $value;
+}
+
+/**
+ * Sanitize select post option.
+ *
+ * @param mixed $value Input value.
+ * @return string|int
+ */
+function smn_notice_sanitize_select_post( $value ) {
+	if ( 'all' === $value ) {
+		return 'all';
+	}
+
+	return absint( $value );
+}
+
+/**
+ * Sanitize hide behavior.
+ *
+ * @param mixed $value Input value.
+ * @return int
+ */
+function smn_notice_sanitize_hide_behavior( $value ) {
+	$value = (int) $value;
+
+	return in_array( $value, array( 1, 2 ), true ) ? $value : 1;
+}
+
+/**
+ * Sanitize position.
+ *
+ * @param string $value Input value.
+ * @return string
+ */
+function smn_notice_sanitize_position( $value ) {
+	return in_array( $value, smn_notice_positions(), true ) ? $value : 'bottom center';
+}
+
+/**
+ * Sanitize style.
+ *
+ * @param string $value Input value.
+ * @return string
+ */
+function smn_notice_sanitize_style( $value ) {
+	return in_array( $value, smn_notice_styles(), true ) ? $value : 'bootstrap';
+}
+
+/**
+ * Sanitize hide delay.
+ *
+ * @param mixed $value Input value.
+ * @return int
+ */
+function smn_notice_sanitize_hide_delay( $value ) {
+	return max( 0, absint( $value ) );
+}
+
+/**
+ * Sanitize cookie expiry in days.
+ *
+ * @param mixed $value Input value.
+ * @return int
+ */
+function smn_notice_sanitize_cookie_expire( $value ) {
+	return max( 0, absint( $value ) );
+}
 
 // Register plugin page settigns
-function smn_notice_register_settings(){
+function smn_notice_register_settings() {
+	register_setting( 'smn_options_group', 'smn_enable_notice', array( 'sanitize_callback' => 'smn_notice_sanitize_toggle' ) );
+	register_setting( 'smn_options_group', 'smn_notice_text', array( 'sanitize_callback' => 'smn_notice_sanitize_text' ) );
+	register_setting( 'smn_options_group', 'smn_select_post', array( 'sanitize_callback' => 'smn_notice_sanitize_select_post' ) );
+	register_setting( 'smn_options_group', 'smn_hide', array( 'sanitize_callback' => 'smn_notice_sanitize_hide_behavior' ) );
+	register_setting( 'smn_options_group', 'smn_hide_delay', array( 'sanitize_callback' => 'smn_notice_sanitize_hide_delay' ) );
+	register_setting( 'smn_options_group', 'smn_position', array( 'sanitize_callback' => 'smn_notice_sanitize_position' ) );
+	register_setting( 'smn_options_group', 'smn_style', array( 'sanitize_callback' => 'smn_notice_sanitize_style' ) );
+	register_setting( 'smn_options_group', 'smn_cookie_expire', array( 'sanitize_callback' => 'smn_notice_sanitize_cookie_expire' ) );
+	register_setting( 'smn_options_group', 'smn_hide_mobile', array( 'sanitize_callback' => 'smn_notice_sanitize_toggle' ) );
 
-    register_setting( 'smn_options_group', 'smn_notice_text' );
-    register_setting( 'smn_options_group', 'smn_select_post' );
-    register_setting( 'smn_options_group', 'smn_hide' );
-    register_setting( 'smn_options_group', 'smn_hide_delay' );
-    register_setting( 'smn_options_group', 'smn_position' );
-    register_setting( 'smn_options_group', 'smn_style' );
-    register_setting( 'smn_options_group', 'smn_cookie_expire' );
-    add_option( 'smn_hide_delay', '5000' );
-    add_option( 'smn_cookie_expire', '0' );
-
-    
+	add_option( 'smn_enable_notice', 1 );
+	add_option( 'smn_hide_delay', 5000 );
+	add_option( 'smn_cookie_expire', 0 );
 }
 add_action( 'admin_init', 'smn_notice_register_settings' );
 
 // Create Option Page
-function smn_options_page(){
-    add_options_page( 'Simple Notice Settigns', 'Simple Notice', 'manage_options', 'smn_notice', 'smn_notice_display' );
+function smn_options_page() {
+	add_options_page( 'Simple Notice Settings', 'Simple Notice', 'manage_options', 'smn_notice', 'smn_notice_display' );
 }
 add_action( 'admin_menu', 'smn_options_page' );
 
 // Display options page
-function smn_notice_display(){
-    ?>
-    
-        <div class="wrap simple-notice">
-            <h1>Simple Notice Settigns</h1>
-            
-            <form id="smn_notice_form" method="post" action="options.php">
-                
-                <?php 
-                    settings_fields( 'smn_options_group' );
-                    $smn_notice_text    = get_option('smn_notice_text');
-                    $smn_select_post    = get_option('smn_select_post');
-                    $smn_hide_val       = get_option('smn_hide');
-                    $smn_hide_delay     = get_option('smn_hide_delay');
-                    $smn_position       = get_option('smn_position');
-                    $smn_style          = get_option('smn_style');
-                    $smn_cookie_expire  = get_option('smn_cookie_expire');
-                    
-                ?>
-                
-                <!-- Smn Options Area -->
-                <div class="smn_fields">
-                    
-                    <!-- Notice Text Field -->
-                    <div class="smn_group">
-                        <label for="smn_notice_text"><?php _e( 'Notice Text', 'smn_notice' ); ?></label>
-                        <input type="text" id="smn_notice_text" name="smn_notice_text" value="<?php echo esc_attr( $smn_notice_text ); ?>" placeholder="Enter your text..." />
-                    </div>
-                    
-                    <!-- Notification Page Field -->
-                    <div class="smn_group">
-                        <label for="smn_select_post"><?php _e( 'Select Page', 'smn_notice' ); ?></label>
-                        <select id="smn_select_post" name="smn_select_post">
-                            <option value="all" <?php echo ( $smn_select_post == 'all' ) ? "selected" : " "; ?> ><?php _e( 'All', 'smn_notice' ); ?></option>
-                            
-                            <!-- Pages -->
-                            <option class="option_posts" disabled><?php _e( 'Pages', 'smn_notice' ); ?></option>
-                            <?php 
-                                $smn_pages = get_pages(); 
-                                foreach ( $smn_pages as $page ) : ?>
-                                    <option value="<?php echo esc_attr( $page->ID ); ?>" <?php echo ( $smn_select_post == $page->ID ) ? "selected" : " "; ?> >
-                                        <?php echo esc_html( $page->post_title ); ?>
-                                    </option>
-                            <?php endforeach; ?>
-                            
-                            <!-- Posts -->
-                            <option class="option_posts" disabled><?php _e( 'Posts', 'smn_notice' ); ?></option>
-                            <?php 
-                                global $post;
-                                $args = array( 
-                                        'posts_per_page' => -1
-                                    );
-                                $posts = get_posts( $args ); 
-                                foreach ( $posts as $post ) : ?>
-                                    <option value="<?php echo esc_attr( $post->ID ); ?>" <?php echo ( $smn_select_post == $post->ID ) ? "selected" : " "; ?> >
-                                        <?php echo esc_html( $post->post_title ); ?>
-                                    </option>
-                            <?php endforeach; wp_reset_postdata();?>
-                            
-                        </select>
-                    </div>
-                    
-                    <!-- Set how to hide the notice Field -->
-                    <div class="smn_group">
-                        <label for="smn_hide"><?php _e( 'Set how to hide the notice', 'smn_notice' ); ?></label>
-                        <select id="smn_hide" name="smn_hide">
-                          <option value="1" <?php echo ( $smn_hide_val == 1 ) ? "selected" : " "; ?> ><?php _e( 'Atuo Hide', 'smn_notice' ); ?></option>
-                          <option value="2" <?php echo ( $smn_hide_val == 2 ) ? "selected" : " "; ?> ><?php _e( 'Click to Hide', 'smn_notice' ); ?></option>
-                        </select>
-                        
-                        <div id="smn_delay_field">
-                            <p class="description">Enter a number in milliseconds Defaut is: "5000"</p>
-                            <input type="text" id="smn_hide_delay" name="smn_hide_delay" value="<?php echo esc_attr( $smn_hide_delay ); ?>" />
-                        </div>
-                        
-                    </div>
-                    
-                    <!-- Notice Position Field -->
-                    <div class="smn_group">
-                        <label for="smn_position"><?php _e( 'Notice Position', 'smn_notice' ); ?></label>
-                        <p class="description">Select notice bar position Defaut is: "bottom center"</p>
-                        <select id="smn_position" name="smn_position">
-                          <option value="left top" <?php echo ( $smn_position == 'left top' ) ? "selected" : " "; ?> ><?php _e( 'Top Left', 'smn_notice' ); ?></option>
-                          <option value="top center" <?php echo ( $smn_position == 'top center' ) ? "selected" : " "; ?> ><?php _e( 'Top Center', 'smn_notice' ); ?></option>
-                          <option value="top right" <?php echo ( $smn_position == 'top right' ) ? "selected" : " "; ?> ><?php _e( 'Top Right', 'smn_notice' ); ?></option>
-                          <option value="left middle" <?php echo ( $smn_position == 'left middle' ) ? "selected" : " "; ?> ><?php _e( 'Left Middle', 'smn_notice' ); ?></option>
-                          <option value="right middle" <?php echo ( $smn_position == 'right middle' ) ? "selected" : " "; ?> ><?php _e( 'Right Middle', 'smn_notice' ); ?></option>
-                          <option value="left bottom" <?php echo ( $smn_position == 'left bottom' ) ? "selected" : " "; ?> ><?php _e( 'Bottom Left', 'smn_notice' ); ?></option>
-                          <option value="bottom center" <?php echo ( $smn_position == 'bottom center' ) ? "selected" : " "; ?> ><?php _e( 'Bottom Center', 'smn_notice' ); ?></option>
-                          <option value="right bottom" <?php echo ( $smn_position == 'right bottom' ) ? "selected" : " "; ?> ><?php _e( 'Bottom Right', 'smn_notice' ); ?></option>
-                        </select>
-                    </div>
-                    
-                    <!-- Notice Style Field -->
-                    <div class="smn_group">
-                        <label for="smn_style"><?php _e( 'Notice Style', 'smn_notice' ); ?></label>
-                        <select id="smn_style" name="smn_style">
-                          <option value="bootstrap" <?php echo ( $smn_style == 'bootstrap' ) ? "selected" : " "; ?> ><?php _e( 'Bootstrap', 'smn_notice' ); ?></option>
-                          <option value="happyblue" <?php echo ( $smn_style == 'happyblue' ) ? "selected" : " "; ?> ><?php _e( 'Happy Blue', 'smn_notice' ); ?></option>
-                          <option value="blackBg" <?php echo ( $smn_style == 'blackBg' ) ? "selected" : " "; ?> ><?php _e( 'Black BG', 'smn_notice' ); ?></option>
-                        </select>
-                    </div>
-                    
-                    <!-- Notice Time Field -->
-                    <div class="smn_group">
-                        <label for="smn_cookie_expire"><?php _e( 'Show notice after this days', 'smn_notice' ); ?></label>
-                        <p class="description">How many days later you want to show the notice again? <strong>"0 for always"</strong></p>
-                        <input type="number" id="smn_cookie_expire" name="smn_cookie_expire" value="<?php echo esc_attr( $smn_cookie_expire ); ?>" />
-                    </div>
-                    
-                </div>
-                
-                <!-- Smn Shortcode area -->
-                <div class="smn_shortcode">
-                    <h2>You can use shortcode</h2>
-                    <p class="description">You can use shortcode to show notification as button or link tooltip</p>
-                    <code>
-                        [smn_notice_btn text="My button" hide="auto" position="top" style="bootstrap"]
-                    </code>
-                </div>
-                
-                <?php submit_button(); ?>       
-            </form>
-        </div>
-    
-    <?php
+function smn_notice_display() {
+	?>
+
+		<div class="wrap simple-notice">
+			<h1><?php esc_html_e( 'Simple Notice Settings', 'smn_notice' ); ?></h1>
+
+			<form id="smn_notice_form" method="post" action="options.php">
+
+				<?php
+					settings_fields( 'smn_options_group' );
+					$smn_enable        = (int) get_option( 'smn_enable_notice', 1 );
+					$smn_notice_text   = (string) get_option( 'smn_notice_text', '' );
+					$smn_select_post   = get_option( 'smn_select_post', 'all' );
+					$smn_hide_val      = (int) get_option( 'smn_hide', 1 );
+					$smn_hide_delay    = (int) get_option( 'smn_hide_delay', 5000 );
+					$smn_position      = get_option( 'smn_position', 'bottom center' );
+					$smn_style         = get_option( 'smn_style', 'bootstrap' );
+					$smn_cookie_expire = (int) get_option( 'smn_cookie_expire', 0 );
+					$smn_hide_mobile   = (int) get_option( 'smn_hide_mobile', 0 );
+
+				?>
+
+				<!-- Smn Options Area -->
+				<div class="smn_fields">
+
+					<!-- Enable notice -->
+					<div class="smn_group">
+						<label for="smn_enable_notice"><?php esc_html_e( 'Enable notice', 'smn_notice' ); ?></label>
+						<input type="checkbox" id="smn_enable_notice" name="smn_enable_notice" value="1" <?php checked( 1, $smn_enable ); ?> />
+						<p class="description"><?php esc_html_e( 'Turn the notice on or off across the site.', 'smn_notice' ); ?></p>
+					</div>
+
+					<!-- Notice Text Field -->
+					<div class="smn_group">
+						<label for="smn_notice_text"><?php esc_html_e( 'Notice Text', 'smn_notice' ); ?></label>
+						<input type="text" id="smn_notice_text" name="smn_notice_text" value="<?php echo esc_attr( $smn_notice_text ); ?>" placeholder="<?php esc_attr_e( 'Enter your text...', 'smn_notice' ); ?>" />
+					</div>
+
+					<!-- Notification Page Field -->
+					<div class="smn_group">
+						<label for="smn_select_post"><?php esc_html_e( 'Select Page', 'smn_notice' ); ?></label>
+						<select id="smn_select_post" name="smn_select_post">
+							<option value="all" <?php selected( 'all', $smn_select_post ); ?> ><?php esc_html_e( 'All', 'smn_notice' ); ?></option>
+
+							<!-- Pages -->
+							<option class="option_posts" disabled><?php esc_html_e( 'Pages', 'smn_notice' ); ?></option>
+							<?php
+								$smn_pages = get_pages();
+								foreach ( $smn_pages as $page ) :
+									?>
+									<option value="<?php echo esc_attr( $page->ID ); ?>" <?php selected( $smn_select_post, $page->ID ); ?> >
+										<?php echo esc_html( $page->post_title ); ?>
+									</option>
+							<?php endforeach; ?>
+
+							<!-- Posts -->
+							<option class="option_posts" disabled><?php esc_html_e( 'Posts', 'smn_notice' ); ?></option>
+							<?php
+								global $post;
+								$args  = array(
+									'posts_per_page' => -1,
+								);
+								$posts = get_posts( $args );
+								foreach ( $posts as $post ) :
+									?>
+									<option value="<?php echo esc_attr( $post->ID ); ?>" <?php selected( $smn_select_post, $post->ID ); ?> >
+										<?php echo esc_html( $post->post_title ); ?>
+									</option>
+							<?php endforeach; wp_reset_postdata(); ?>
+
+						</select>
+					</div>
+
+					<!-- Set how to hide the notice Field -->
+					<div class="smn_group">
+						<label for="smn_hide"><?php esc_html_e( 'Set how to hide the notice', 'smn_notice' ); ?></label>
+						<select id="smn_hide" name="smn_hide">
+							<option value="1" <?php selected( 1, $smn_hide_val ); ?> ><?php esc_html_e( 'Auto Hide', 'smn_notice' ); ?></option>
+							<option value="2" <?php selected( 2, $smn_hide_val ); ?> ><?php esc_html_e( 'Click to Hide', 'smn_notice' ); ?></option>
+						</select>
+
+						<div id="smn_delay_field">
+							<p class="description"><?php esc_html_e( 'Enter a number in milliseconds. Default is 5000.', 'smn_notice' ); ?></p>
+							<input type="number" min="0" id="smn_hide_delay" name="smn_hide_delay" value="<?php echo esc_attr( $smn_hide_delay ); ?>" />
+						</div>
+
+					</div>
+
+					<!-- Notice Position Field -->
+					<div class="smn_group">
+						<label for="smn_position"><?php esc_html_e( 'Notice Position', 'smn_notice' ); ?></label>
+						<p class="description"><?php esc_html_e( 'Select notice bar position. Default is bottom center.', 'smn_notice' ); ?></p>
+						<select id="smn_position" name="smn_position">
+							<option value="left top" <?php selected( 'left top', $smn_position ); ?> ><?php esc_html_e( 'Top Left', 'smn_notice' ); ?></option>
+							<option value="top center" <?php selected( 'top center', $smn_position ); ?> ><?php esc_html_e( 'Top Center', 'smn_notice' ); ?></option>
+							<option value="top right" <?php selected( 'top right', $smn_position ); ?> ><?php esc_html_e( 'Top Right', 'smn_notice' ); ?></option>
+							<option value="left middle" <?php selected( 'left middle', $smn_position ); ?> ><?php esc_html_e( 'Left Middle', 'smn_notice' ); ?></option>
+							<option value="right middle" <?php selected( 'right middle', $smn_position ); ?> ><?php esc_html_e( 'Right Middle', 'smn_notice' ); ?></option>
+							<option value="left bottom" <?php selected( 'left bottom', $smn_position ); ?> ><?php esc_html_e( 'Bottom Left', 'smn_notice' ); ?></option>
+							<option value="bottom center" <?php selected( 'bottom center', $smn_position ); ?> ><?php esc_html_e( 'Bottom Center', 'smn_notice' ); ?></option>
+							<option value="right bottom" <?php selected( 'right bottom', $smn_position ); ?> ><?php esc_html_e( 'Bottom Right', 'smn_notice' ); ?></option>
+						</select>
+					</div>
+
+					<!-- Notice Style Field -->
+					<div class="smn_group">
+						<label for="smn_style"><?php esc_html_e( 'Notice Style', 'smn_notice' ); ?></label>
+						<select id="smn_style" name="smn_style">
+							<option value="bootstrap" <?php selected( 'bootstrap', $smn_style ); ?> ><?php esc_html_e( 'Bootstrap', 'smn_notice' ); ?></option>
+							<option value="happyblue" <?php selected( 'happyblue', $smn_style ); ?> ><?php esc_html_e( 'Happy Blue', 'smn_notice' ); ?></option>
+							<option value="blackBg" <?php selected( 'blackBg', $smn_style ); ?> ><?php esc_html_e( 'Black BG', 'smn_notice' ); ?></option>
+						</select>
+					</div>
+
+					<!-- Hide on mobile -->
+					<div class="smn_group">
+						<label for="smn_hide_mobile"><?php esc_html_e( 'Hide on mobile', 'smn_notice' ); ?></label>
+						<input type="checkbox" id="smn_hide_mobile" name="smn_hide_mobile" value="1" <?php checked( 1, $smn_hide_mobile ); ?> />
+						<p class="description"><?php esc_html_e( 'Hide the notice on screens smaller than 768px wide.', 'smn_notice' ); ?></p>
+					</div>
+
+					<!-- Notice Time Field -->
+					<div class="smn_group">
+						<label for="smn_cookie_expire"><?php esc_html_e( 'Show notice after this many days', 'smn_notice' ); ?></label>
+						<p class="description"><?php esc_html_e( 'How many days later do you want to show the notice again? Use 0 to show on every visit.', 'smn_notice' ); ?></p>
+						<input type="number" min="0" id="smn_cookie_expire" name="smn_cookie_expire" value="<?php echo esc_attr( $smn_cookie_expire ); ?>" />
+					</div>
+
+				</div>
+
+				<!-- Smn Shortcode area -->
+				<div class="smn_shortcode">
+					<h2><?php esc_html_e( 'You can use the shortcode', 'smn_notice' ); ?></h2>
+					<p class="description"><?php esc_html_e( 'Use the shortcode to show a notification from a button or link tooltip.', 'smn_notice' ); ?></p>
+					<code>
+						[smn_notice_btn text="My button" hide="auto" position="top center" style="bootstrap"]
+					</code>
+				</div>
+
+				<?php submit_button(); ?>
+			</form>
+		</div>
+
+	<?php
 }

--- a/inc/script.php
+++ b/inc/script.php
@@ -1,45 +1,80 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-define( "VERSION", time() );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Get allowed notice positions.
+ *
+ * @return string[]
+ */
+function smn_notice_positions() {
+	return array(
+		'left top',
+		'top center',
+		'top right',
+		'left middle',
+		'right middle',
+		'left bottom',
+		'bottom center',
+		'right bottom',
+	);
+}
+
+/**
+ * Get allowed notice styles.
+ *
+ * @return string[]
+ */
+function smn_notice_styles() {
+	return array(
+		'bootstrap',
+		'happyblue',
+		'blackBg',
+	);
+}
 
 // Load frontend assets
-function smn_frontend_assets(){
-	
-    $smn_select_post =  get_option('smn_select_post');
-    if( is_page( $smn_select_post ) || $smn_select_post == 'all' || is_single( $smn_select_post ) ) {
-        
-        wp_enqueue_style( 'smn-frontend-style', plugins_url( "../assets/frontend/notice.css", __FILE__ ) );
-        wp_enqueue_script( 'smn-cookie-js', plugins_url( "../assets/frontend/jquery.cookie.js", __FILE__), array('jquery'), VERSION, true );
-        wp_enqueue_script( 'smn-notify-js', plugins_url( "../assets/frontend/notify.min.js", __FILE__), array('jquery', 'smn-frontend-js'), VERSION, true );
-        wp_enqueue_script( 'smn-frontend-js', plugins_url( "../assets/frontend/notice.js", __FILE__), array('jquery'), VERSION, true );
-        
-        // Pass to script
-        $smn_pass_script = array( 
-            'smn_text'              => get_option('smn_notice_text'),
-            'smn_hide'              => get_option('smn_hide'),
-            'smn_hide_delay'        => get_option('smn_hide_delay'),
-            'smn_position'          => get_option('smn_position'),
-            'smn_style'             => get_option('smn_style'),
-            'smn_cookie_expire'     => get_option('smn_cookie_expire')
-        );
-        
-        wp_localize_script('smn-frontend-js', 'smn_notice', $smn_pass_script );
-        
-    }
-    
+function smn_frontend_assets() {
+	$smn_select_post = get_option( 'smn_select_post', 'all' );
+	$smn_enable      = (int) get_option( 'smn_enable_notice', 1 );
+
+	if ( ! $smn_enable ) {
+		return;
+	}
+
+	if ( 'all' === $smn_select_post || is_page( (int) $smn_select_post ) || is_single( (int) $smn_select_post ) ) {
+		wp_enqueue_style( 'smn-frontend-style', SMN_NOTICE_URL . 'assets/frontend/notice.css', array(), SMN_NOTICE_VERSION );
+		wp_enqueue_script( 'smn-cookie-js', SMN_NOTICE_URL . 'assets/frontend/jquery.cookie.js', array( 'jquery' ), SMN_NOTICE_VERSION, true );
+		wp_enqueue_script( 'smn-notify-js', SMN_NOTICE_URL . 'assets/frontend/notify.min.js', array( 'jquery' ), SMN_NOTICE_VERSION, true );
+		wp_enqueue_script( 'smn-frontend-js', SMN_NOTICE_URL . 'assets/frontend/notice.js', array( 'jquery', 'smn-cookie-js', 'smn-notify-js' ), SMN_NOTICE_VERSION, true );
+
+		$smn_position = get_option( 'smn_position', 'bottom center' );
+		$smn_style    = get_option( 'smn_style', 'bootstrap' );
+
+		// Pass to script.
+		$smn_pass_script = array(
+			'smn_text'          => wp_strip_all_tags( (string) get_option( 'smn_notice_text', '' ) ),
+			'smn_hide'          => (int) get_option( 'smn_hide', 1 ),
+			'smn_hide_delay'    => (int) get_option( 'smn_hide_delay', 5000 ),
+			'smn_position'      => in_array( $smn_position, smn_notice_positions(), true ) ? $smn_position : 'bottom center',
+			'smn_style'         => in_array( $smn_style, smn_notice_styles(), true ) ? $smn_style : 'bootstrap',
+			'smn_cookie_expire' => (int) get_option( 'smn_cookie_expire', 0 ),
+			'smn_hide_mobile'   => (int) get_option( 'smn_hide_mobile', 0 ),
+		);
+
+		wp_localize_script( 'smn-frontend-js', 'smn_notice', $smn_pass_script );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'smn_frontend_assets' );
 
 
 // Admin Assets
 
-function smn_admin_assets($page_now){
-    
-    if( $page_now == "settings_page_smn_notice" ){
-        wp_enqueue_style( 'smn-admin-style', plugins_url( "../assets/admin/admin.css", __FILE__ ) );
-        wp_enqueue_script( 'smn-admin-js', plugins_url( "../assets/admin/admin.js", __FILE__), array( 'jquery' ), VERSION, true  );
-    }
-    
+function smn_admin_assets( $page_now ) {
+	if ( 'settings_page_smn_notice' === $page_now ) {
+		wp_enqueue_style( 'smn-admin-style', SMN_NOTICE_URL . 'assets/admin/admin.css', array(), SMN_NOTICE_VERSION );
+		wp_enqueue_script( 'smn-admin-js', SMN_NOTICE_URL . 'assets/admin/admin.js', array( 'jquery' ), SMN_NOTICE_VERSION, true );
+	}
 }
 add_action( 'admin_enqueue_scripts', 'smn_admin_assets' );
-

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -1,36 +1,55 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 // Button shortcode
-function smn_notice_button_shortcode( $atts, $content = null ){
+function smn_notice_button_shortcode( $atts, $content = null ) {
+	$atts = shortcode_atts(
+		array(
+			'text'     => __( 'Your button text', 'smn_notice' ),
+			'url'      => '#',
+			'class'    => 'smn-notice-btn',
+			'hide'     => 'auto',
+			'position' => 'top center',
+			'style'    => 'bootstrap',
+		),
+		$atts
+	);
 
-    extract(shortcode_atts( array(
-        'text'      => __( 'Your button text', 'smn' ),
-        'url'       => '#',
-        'class'     => 'smn-notice-btn',
-        'hide'      => 'auto',
-        'position'  => 'top center',
-        'style'     => 'bootstrap'
-    ), $atts ));
-    
-    ob_start();
-?>
-    <a class="<?php echo esc_attr( $class ); ?>" href="<?php echo esc_attr( $url ); ?>"><?php echo esc_html( $text ); ?></a>
-    <script>
-        jQuery(document).ready(function(){
-            jQuery(".<?php echo esc_attr( $class ); ?>").notify( "<?php echo esc_html( $text ); ?>", { 
-                    position:'<?php echo esc_attr( $position ); ?>',
-                    clickToHide: true,
-                    autoHide: false,
-                    autoHideDelay: 3000,
-                    style: 'bootstrap',
-                }
-            );
-        });
-    </script>
+	$class    = sanitize_html_class( $atts['class'] );
+	$position = smn_notice_sanitize_position( $atts['position'] );
+	$style    = smn_notice_sanitize_style( $atts['style'] );
+	$hide     = 'click' === $atts['hide'] ? 'click' : 'auto';
+	$text     = sanitize_text_field( $atts['text'] );
+	$url      = esc_url( $atts['url'] );
 
-<?php
-    return ob_get_clean();
+	wp_enqueue_style( 'smn-frontend-style', SMN_NOTICE_URL . 'assets/frontend/notice.css', array(), SMN_NOTICE_VERSION );
+	wp_enqueue_script( 'smn-cookie-js', SMN_NOTICE_URL . 'assets/frontend/jquery.cookie.js', array( 'jquery' ), SMN_NOTICE_VERSION, true );
+	wp_enqueue_script( 'smn-notify-js', SMN_NOTICE_URL . 'assets/frontend/notify.min.js', array( 'jquery' ), SMN_NOTICE_VERSION, true );
 
+	$auto_hide   = 'auto' === $hide;
+	$notify_args = array(
+		'position'      => $position,
+		'clickToHide'   => ! $auto_hide,
+		'autoHide'      => $auto_hide,
+		'autoHideDelay' => 3000,
+		'style'         => $style,
+	);
+
+	$script = sprintf(
+		'jQuery(function($){$(".%1$s").notify(%2$s, %3$s);});',
+		esc_js( $class ),
+		wp_json_encode( $text ),
+		wp_json_encode( $notify_args )
+	);
+	wp_add_inline_script( 'smn-notify-js', $script );
+
+	return sprintf(
+		'<a class="%1$s" href="%2$s">%3$s</a>',
+		esc_attr( $class ),
+		esc_url( $url ),
+		esc_html( $text )
+	);
 }
 add_shortcode( 'smn_notice_btn', 'smn_notice_button_shortcode' );

--- a/simple-notice.php
+++ b/simple-notice.php
@@ -12,24 +12,39 @@
  * Domain Path: /languages
  */
  
- 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+define( 'SMN_NOTICE_VERSION', '1.1.0' );
+define( 'SMN_NOTICE_PATH', plugin_dir_path( __FILE__ ) );
+define( 'SMN_NOTICE_URL', plugin_dir_url( __FILE__ ) );
 
 /***************************
 * Includes
 ***************************/
-include( plugin_dir_path( __FILE__ ) . '/inc/script.php' );
-include( plugin_dir_path( __FILE__ ) . '/inc/admin-options.php' );
-include( plugin_dir_path( __FILE__ ) . '/inc/shortcode.php' );
+include SMN_NOTICE_PATH . 'inc/script.php';
+include SMN_NOTICE_PATH . 'inc/admin-options.php';
+include SMN_NOTICE_PATH . 'inc/shortcode.php';
+
+/**
+ * Load plugin textdomain for translations.
+ */
+function smn_notice_load_textdomain() {
+	load_plugin_textdomain( 'smn_notice', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'smn_notice_load_textdomain' );
 
 
 // Add settigns page link to plugin page
-function smn_plugin_action_links( $links ){
-    
-    $links = array_merge( array(
-		'<a href="' . esc_url( admin_url( '/options-general.php?page=smn_notice' ) ) . '">' . __( 'Settings', 'smn_notice' ) . '</a>'
-	), $links );
-    return $links;
-    
+function smn_plugin_action_links( $links ) {
+	$links = array_merge(
+		array(
+			'<a href="' . esc_url( admin_url( 'options-general.php?page=smn_notice' ) ) . '">' . esc_html__( 'Settings', 'smn_notice' ) . '</a>',
+		),
+		$links
+	);
+
+	return $links;
 }
 add_action( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'smn_plugin_action_links' );


### PR DESCRIPTION
### Motivation

- Harden the plugin by adding constants, clearer asset URLs, and textdomain support for translations.
- Prevent invalid/unsafe option values by adding sanitization and validated setting callbacks.
- Improve UX by adding an enable toggle, a hide-on-mobile option, and more predictable frontend behavior.

### Description

- Add plugin constants (`SMN_NOTICE_VERSION`, `SMN_NOTICE_PATH`, `SMN_NOTICE_URL`), safer includes, and load the plugin textdomain for translations in `simple-notice.php`.
- Add sanitizers and validated register_setting callbacks and new settings (`smn_enable_notice`, `smn_hide_mobile`) and refactor the admin UI with clearer labels, defaults, and input types in `inc/admin-options.php`.
- Refactor asset enqueuing and script-localization in `inc/script.php` to use constants, explicit dependencies, sanitized defaults, and enumerations for allowed positions/styles.
- Harden frontend logic and cookie behavior in `assets/frontend/notice.js` to guard against missing data, respect the hide-on-mobile setting, only set the cookie when a notice was shown, and parse numeric values safely.
- Modernize the shortcode in `inc/shortcode.php` to use `shortcode_atts`, sanitization (`sanitize_html_class`, `sanitize_text_field`, `esc_url`), enqueue assets properly, and inject an inline script with `wp_add_inline_script` for the specific button instance.
- Update `README.md` with clearer usage, features, and shortcode documentation.

### Testing

- No automated tests were executed as part of this change.